### PR TITLE
[FIX] Error Could not import library pdf417gen

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ xlrd==1.2.0; python_version >= '3.8'
 XlsxWriter==1.1.2
 xlwt==1.3.*
 zeep==3.4.0
+pdf417gen


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix for ERROR on odoo.addons.l10n_cl_edi.models.account_move: Could not import library pdf417gen
when tried to upgrade from v14 to v16
The module l10n_cl_edi use this library
Current behavior before PR:
The project builds the instance without this library and put the instance on Error state when you try to upgrade
Desired behavior after PR is merged:
The library must be on base for fullfill the requirement of the module.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
